### PR TITLE
Update missionStatus model to use "CommRelay" only

### DIFF
--- a/models/missionUpdate.v1.json
+++ b/models/missionUpdate.v1.json
@@ -12,9 +12,7 @@
         "FollowPath",
         "Scan",
         "Servoing",
-        "CommRelayFixed",
-        "CommRelayArea",
-        "CommRelayFollow"
+        "CommRelay"
       ]
     },
     "missionStatus": {


### PR DESCRIPTION
This change aligns the mission type with the names used in the repositories